### PR TITLE
Support additional subscription params

### DIFF
--- a/controllers/MailchimpSubscribe_ListController.php
+++ b/controllers/MailchimpSubscribe_ListController.php
@@ -18,6 +18,7 @@ class MailchimpSubscribe_ListController extends BaseController {
     $formListId = craft()->request->getParam('lid', '');
     $vars = craft()->request->getParam('mcvars', array());
     $doubleOptIn = craft()->request->getParam('double_optin');
+    $emailType = craft()->request->getParam('email_type');
     $updateExisting = craft()->request->getParam('update_existing');
     $replaceInterests = craft()->request->getParam('replace_interests');
     $sendWelcome = craft()->request->getParam('send_welcome');
@@ -45,7 +46,7 @@ class MailchimpSubscribe_ListController extends BaseController {
 
         // loop over list id's and subscribe
         foreach ($listIdArr as $listId) {
-          $retval = $api->listSubscribe($listId, $email, $vars, 'html', $doubleOptIn, $updateExisting, $replaceInterests, $sendWelcome);
+          $retval = $api->listSubscribe($listId, $email, $vars, $emailType, $doubleOptIn, $updateExisting, $replaceInterests, $sendWelcome);
         }
         
         if ($api->errorCode) { // an api error occured 

--- a/controllers/MailchimpSubscribe_ListController.php
+++ b/controllers/MailchimpSubscribe_ListController.php
@@ -17,6 +17,10 @@ class MailchimpSubscribe_ListController extends BaseController {
     $email = craft()->request->getParam('email', '');
     $formListId = craft()->request->getParam('lid', '');
     $vars = craft()->request->getParam('mcvars', array());
+    $doubleOptIn = craft()->request->getParam('double_optin');
+    $updateExisting = craft()->request->getParam('update_existing');
+    $replaceInterests = craft()->request->getParam('replace_interests');
+    $sendWelcome = craft()->request->getParam('send_welcome');
     $redirect = craft()->request->getParam('redirect', '');
     
     if ($email!='' && $this->_validateEmail($email)) { // validate email
@@ -41,7 +45,7 @@ class MailchimpSubscribe_ListController extends BaseController {
 
         // loop over list id's and subscribe
         foreach ($listIdArr as $listId) {
-          $retval = $api->listSubscribe($listId, $email, $vars);
+          $retval = $api->listSubscribe($listId, $email, $vars, 'html', $doubleOptIn, $updateExisting, $replaceInterests, $sendWelcome);
         }
         
         if ($api->errorCode) { // an api error occured 


### PR DESCRIPTION
I can see that the ``merge_vars`` are supported but I couldn't see a way to be able to define additional list/subscribe params. 

This has helped me out as a quick fix and there maybe be a more elegant way to do this. Ultimately it would be nice to be able to have access to these params in the master plugin. 

Cheers