### PR TITLE
Added the ability to disable "double opt-in" to settings page

### DIFF
--- a/MailchimpSubscribePlugin.php
+++ b/MailchimpSubscribePlugin.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MailChimp Signup plugin
- * 
+ *
  * https://github.com/aelvan/mailchimp-subscribe-craft
  *
  * @author André Elvan
@@ -18,7 +18,7 @@ class MailchimpSubscribePlugin extends BasePlugin
 
   public function getVersion()
   {
-      return '0.4';
+      return '0.5';
   }
 
   public function getDeveloper()
@@ -35,25 +35,27 @@ class MailchimpSubscribePlugin extends BasePlugin
   {
       return false;
   }
-  
+
   protected function defineSettings()
   {
     return array(
-         'mcsubApikey' => array(AttributeType::String, 'default' => ''),
-         'mcsubListId' => array(AttributeType::String, 'default' => ''),
+         'mcsubApikey'      => array(AttributeType::String, 'default' => ''),
+         'mcsubListId'      => array(AttributeType::String, 'default' => ''),
+         'mcsubDoubleOptIn' => array(AttributeType::Bool, 'default' => 'true')
     );
   }
-  
+
   public function getSettingsHtml()
   {
     $config_settings = array();
     $config_settings['mcsubApikey'] = craft()->config->get('mcsubApikey');
     $config_settings['mcsubListId'] = craft()->config->get('mcsubListId');
-    
+    $config_settings['mcsubDoubleOptIn'] = craft()->config->get('mcsubDoubleOptIn');
+
     return craft()->templates->render('mailchimpsubscribe/settings', array(
       'settings' => $this->getSettings(),
       'config_settings' => $config_settings
     ));
-  } 
-  
+  }
+
 }

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ Configuration
 To use the plugin you need to create an API key from the MailChimp control panel, and create a list (or use one you already have). 
 
 You can configure MailChimp Subscribe either through the plugins settings in the control panel, or 
-by adding the settings to the general config file (usually found in /craft/config/general.php). Configuring it in
-the settings file is more flexible, since you can set up the config file to have different settings depending on the 
-environment.
+by adding the settings to the general config file (usually found in /craft/config/general.php). Configuring it in the settings file is more flexible, since you can set up the config file to have different settings depending on the environment.
+
 
 
 ####Example
 
     'mcsubApikey' => 'xxxxxxxxxxxxxxxxxxxxx-us2',
     'mcsubListId' => '2fd6ec09cf',
+    'mcsubDoubleOptIn => false
 
 If you have multiple lists you want users to subscribe to, each form can have a hidden field with a name of "lid" and the "value" as your list id. The plugin will use this list id on form submit. 
 
@@ -161,6 +161,9 @@ Example:
 
 Changelog
 ---
+### Version 0.5
+ - Added support for disabling double opt-in (particularly useful with Ajax submission).
+
 ### Version 0.4
  - Added support for multiple list id's.
  

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,3 +1,4 @@
+{% import "_includes/forms" as forms %}
 <style>
   .setting-is-disabled { font-size: 11px; font-style: italic; color: #999; }
 </style>
@@ -11,10 +12,10 @@
 		<input class="text fullwidth" type="text" id="mcsubApikey" name="mcsubApikey" value="{% if config_settings.mcsubApikey is not null %}{{ config_settings.mcsubApikey }}{% else %}{{ settings.mcsubApikey }}{% endif %}"{% if config_settings.mcsubApikey is not null %} disabled="disabled"{% endif %}>
     {% if config_settings.mcsubApikey is not null %}
       <p class="setting-is-disabled">This setting has been configured in the config file.</p>
-    {% endif %}      
+    {% endif %}
 	</div>
 </div>
-  
+
 <div class="field" id="mcsubListId-field">
   <div class="heading">
     <label for="mcsubListId">List ID</label>
@@ -24,6 +25,18 @@
 		<input class="text fullwidth" type="text" id="mcsubListId" name="mcsubListId" value="{% if config_settings.mcsubListId is not null %}{{ config_settings.mcsubListId }}{% else %}{{ settings.mcsubListId }}{% endif %}"{% if config_settings.mcsubListId is not null %} disabled="disabled"{% endif %}>
     {% if config_settings.mcsubListId is not null %}
       <p class="setting-is-disabled">This setting has been configured in the config file.</p>
-    {% endif %}      
+    {% endif %}
 	</div>
 </div>
+
+{{ forms.lightswitchField({
+        label: "Double Opt-In"|t,
+        instructions: "Optional flag to control whether a double opt-in confirmation message is sent, defaults to true."|t,
+        id: 'mcsubDoubleOptIn',
+        name: 'mcsubDoubleOptIn',
+        on: settings.mcsubDoubleOptIn,
+        autofocus: false,
+        required: false
+    })
+}}
+

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -6,7 +6,7 @@
 <div class="field" id="mcsubApikey-field">
   <div class="heading">
     <label for="mcsubApikey">API Key</label>
-		<p class="instructions">Create it in your mailchimp account</p>
+		<p class="instructions">Create it in your MailChimp account</p>
   </div>
 	<div class="input">
 		<input class="text fullwidth" type="text" id="mcsubApikey" name="mcsubApikey" value="{% if config_settings.mcsubApikey is not null %}{{ config_settings.mcsubApikey }}{% else %}{{ settings.mcsubApikey }}{% endif %}"{% if config_settings.mcsubApikey is not null %} disabled="disabled"{% endif %}>
@@ -31,7 +31,7 @@
 
 {{ forms.lightswitchField({
         label: "Double Opt-In"|t,
-        instructions: "Optional flag to control whether a double opt-in confirmation message is sent, defaults to true."|t,
+        instructions: "Optional flag to control whether a double opt-in confirmation message is sent, defaults to <code>true</code>. <em>Abusing this may cause your account to be suspended.</em>"|t,
         id: 'mcsubDoubleOptIn',
         name: 'mcsubDoubleOptIn',
         on: settings.mcsubDoubleOptIn,


### PR DESCRIPTION
Occasionally you want to have emails added directly to the list skipping the "double opt-in" that MailChimp uses by default. This adds a light switch field to the settings page (following MailChimp's default) giving ability to turn off the double opt-in and add the subscriber directly to the list.