### PR TITLE
Allow interests groups to be merged with current groups

### DIFF
--- a/mailchimpsubscribe/services/MailchimpSubscribeService.php
+++ b/mailchimpsubscribe/services/MailchimpSubscribeService.php
@@ -57,7 +57,7 @@ class MailchimpSubscribeService extends BaseApplicationComponent
                     $member = $this->getMemberByEmail($email, $listId);
                     if ($member) {
                         // Merge interest groups
-                        $interests = array_merge($interests, $member['interests']);
+                        $interests = array_merge($member['interests'], $interests);
                     }
                     // Subscribe
                     $postVars = array(

--- a/mailchimpsubscribe/services/MailchimpSubscribeService.php
+++ b/mailchimpsubscribe/services/MailchimpSubscribeService.php
@@ -41,14 +41,6 @@ class MailchimpSubscribeService extends BaseApplicationComponent
                 // split id string on | in case more than one list id is supplied
                 $listIdArr = explode("|", $listIdStr);
 
-                // convert groups to input format if present
-                if (isset($vars['group']) && count($vars['group'])) {
-                    $vars['GROUPINGS'] = array();
-                    foreach ($vars['group'] as $key => $vals) {
-                        $vars['GROUPINGS'][] = array('id' => $key, 'groups' => implode(',', $vals));
-                    }
-                }
-
                 // convert interest groups if present
                 $interests = array();
                 if (isset($vars['interests']) && count($vars['interests'])) {

--- a/mailchimpsubscribe/services/MailchimpSubscribeService.php
+++ b/mailchimpsubscribe/services/MailchimpSubscribeService.php
@@ -57,7 +57,7 @@ class MailchimpSubscribeService extends BaseApplicationComponent
                     $member = $this->getMemberByEmail($email, $listId);
                     if ($member) {
                         // Merge interest groups
-                        $interests = array_merge($member['interests'], $interests);
+                        $interests = array_merge((array) $member['interests'], $interests);
                     }
                     // Subscribe
                     $postVars = array(


### PR DESCRIPTION
Interest groups should be merged (and not overwritten) if the email address provided already belongs to the list