### PR TITLE
Check if we have variables before merging them

### DIFF
--- a/src/services/MailchimpSubscribeService.php
+++ b/src/services/MailchimpSubscribeService.php
@@ -81,7 +81,7 @@ class MailchimpSubscribeService extends Component
                 'email_address' => $email
             ];
 
-            if (\count($vars) > 0) {
+            if (isset($vars) && \count($vars) > 0) {
                 $postVars['merge_fields'] = $vars;
             }
 


### PR DESCRIPTION
I was trying to build a form that only has an email field and the service crashed on subscribing.
Added an extra check to the `MailchimpSubscribeService` to check that `$vars` is actually set before merging it.

Cheers
Jan