### PR TITLE
Possible to request more than 10 interests

### DIFF
--- a/mailchimpsubscribe/variables/MailchimpSubscribeVariable.php
+++ b/mailchimpsubscribe/variables/MailchimpSubscribeVariable.php
@@ -4,9 +4,9 @@ namespace Craft;
 class MailchimpSubscribeVariable
 {
 
-    public function getListInterestGroups($listId)
+    public function getListInterestGroups($listId, $count = 10)
     {
-        return craft()->mailchimpSubscribe->getListInterestGroups($listId);
+        return craft()->mailchimpSubscribe->getListInterestGroups($listId, $count);
     }
 
     public function checkIfSubscribed($email, $formListId)


### PR DESCRIPTION
Mailchimps count is by default 10. When u need more interests you need to add this via url.