### PR TITLE
Multisite support for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,24 @@ confirm their subscription before being added to the audience.
 
 ---
 
+The plugin config also supports using different settings on a per-site basis. This works like Craft's general config does:
+
+    <?php
+    return [
+        'apiKey' => [
+            'siteHandleA' => 'xxxxxxxxxxxxxxxxxxx-us2',
+            'siteHandleB' => 'xxxxxxxxxxxxxxxxxxx-us2',
+        ],
+        'audienceId' => [
+            'siteHandleA' => '7fw6eq98ca',
+            'siteHandleB' => '3fa8ew9fce',
+        ],
+        'doubleOptIn' => [
+            'siteHandleA' => true,
+            'siteHandleB' => false,
+        ],
+    ];
+
 ## Usage
 
 Mailchimp Subscribe let's you subscribe, unsubscribe and delete members to/from Mailchimp audiences.   

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -9,6 +9,7 @@
 namespace aelvan\mailchimpsubscribe\models;
 
 use craft\base\Model;
+use craft\helpers\ConfigHelper;
 
 class Settings extends Model
 {
@@ -16,4 +17,16 @@ class Settings extends Model
     public $listId = '';
     public $audienceId = '';
     public $doubleOptIn = true;
+
+    public function getApiKey($siteHandle = null) {
+        return ConfigHelper::localizedValue($this->apiKey, $siteHandle);
+    }
+
+    public function getAudienceId($siteHandle = null) {
+        return ConfigHelper::localizedValue($this->audienceId, $siteHandle);
+    }
+
+    public function getDoubleOptIn($siteHandle = null) {
+        return ConfigHelper::localizedValue($this->doubleOptIn, $siteHandle);
+    }
 }

--- a/src/services/MailchimpSubscribeService.php
+++ b/src/services/MailchimpSubscribeService.php
@@ -398,7 +398,7 @@ class MailchimpSubscribeService extends Component
         $audienceId = $this->prepAudienceId($audienceId);
 
         // check if we got an api key and  id
-        if ($settings->getApiKeu() === '' || $audienceId === '') {
+        if ($settings->getApiKey() === '' || $audienceId === '') {
             Craft::error('API Key or Audience ID not supplied. Check your settings.', __METHOD__);
             return null;
         }

--- a/src/services/MailchimpSubscribeService.php
+++ b/src/services/MailchimpSubscribeService.php
@@ -54,7 +54,7 @@ class MailchimpSubscribeService extends Component
         // get list id string
         $audienceId = $this->prepAudienceId($audienceId);
 
-        if ($settings->apiKey === '' || $audienceId === '') { // error, no API key or list id
+        if ($settings->getApiKey() === '' || $audienceId === '') { // error, no API key or list id
             return new SubscribeResponse([
                 'success' => false,
                 'errorCode' => '2000',
@@ -82,8 +82,8 @@ class MailchimpSubscribeService extends Component
         
         // Build the post variables
         $postVars = [
-            'status_if_new' => $settings->doubleOptIn ? 'pending' : 'subscribed',
-            'status' => $settings->doubleOptIn ? 'pending' : 'subscribed',
+            'status_if_new' => $settings->getDoubleOptIn() ? 'pending' : 'subscribed',
+            'status' => $settings->getDoubleOptIn() ? 'pending' : 'subscribed',
             'email_type' => $opts['email_type'],
             'email_address' => $email,
         ];
@@ -195,7 +195,7 @@ class MailchimpSubscribeService extends Component
         // get list id string
         $audienceId = $this->prepAudienceId($audienceId);
 
-        if ($settings->apiKey === '' || $audienceId === '') { // error, no API key or list id
+        if ($settings->getApiKey() === '' || $audienceId === '') { // error, no API key or list id
             return new SubscribeResponse([
                 'action' => 'unsubscribe',
                 'success' => false,
@@ -279,7 +279,7 @@ class MailchimpSubscribeService extends Component
         // get list id string
         $audienceId = $this->prepAudienceId($audienceId);
 
-        if ($settings->apiKey === '' || $audienceId === '') { // error, no API key or list id
+        if ($settings->getApiKey() === '' || $audienceId === '') { // error, no API key or list id
             return new SubscribeResponse([
                 'action' => 'delete',
                 'success' => false,
@@ -361,7 +361,7 @@ class MailchimpSubscribeService extends Component
         }
 
         // check if we got an api key and a audience id
-        if ($settings->apiKey === '' || $audienceId === '') {
+        if ($settings->getApiKey() === '' || $audienceId === '') {
             Craft::error('API Key or Audience ID not supplied. Check your settings.', __METHOD__);
             return null;
         }
@@ -398,7 +398,7 @@ class MailchimpSubscribeService extends Component
         $audienceId = $this->prepAudienceId($audienceId);
 
         // check if we got an api key and  id
-        if ($settings->apiKey === '' || $audienceId === '') {
+        if ($settings->getApiKeu() === '' || $audienceId === '') {
             Craft::error('API Key or Audience ID not supplied. Check your settings.', __METHOD__);
             return null;
         }
@@ -440,7 +440,7 @@ class MailchimpSubscribeService extends Component
         }
 
         // check if we got an api key and id
-        if ($settings->apiKey === '' || $audienceId === '') {
+        if ($settings->getApiKey() === '' || $audienceId === '') {
             Craft::error('API Key or Audience ID not supplied. Check your settings.', __METHOD__);
             return null;
         }
@@ -468,7 +468,7 @@ class MailchimpSubscribeService extends Component
         $audienceId = $this->prepAudienceId($audienceId);
 
         // check if we got an api key and a list id
-        if ($settings->apiKey === '' || $audienceId === '') { // error, no API key or list id
+        if ($settings->getApiKey() === '' || $audienceId === '') { // error, no API key or list id
             Craft::error('API Key or Audience ID not supplied. Check your settings.', __METHOD__);
             return null;
         }
@@ -538,7 +538,7 @@ class MailchimpSubscribeService extends Component
         }
 
         // check if we got an api key and a list id
-        if ($settings->apiKey === '' || $audienceId === '') { // error, no API key or list id
+        if ($settings->getApiKey() === '' || $audienceId === '') { // error, no API key or list id
             Craft::error('API Key or Audience ID not supplied. Check your settings.', __METHOD__);
             return null;
         }
@@ -606,7 +606,7 @@ class MailchimpSubscribeService extends Component
         $audienceId = $this->prepAudienceId($audienceId);
 
         // check if we got an api key and a list id
-        if ($settings->apiKey === '' || $audienceId === '') { // error, no API key or list id
+        if ($settings->getApiKey() === '' || $audienceId === '') { // error, no API key or list id
             return $this->getMessage(2000, $email, [], Craft::t('mailchimp-subscribe', 'API Key or Audience ID not supplied. Check your settings.'));
         }
 
@@ -647,7 +647,7 @@ class MailchimpSubscribeService extends Component
         $listId = $this->prepAudienceId($listId);
 
         // check if we got an api key and a list id
-        if ($settings->apiKey === '' || $listId === '') { // error, no API key or list id
+        if ($settings->getApiKey() === '' || $listId === '') { // error, no API key or list id
             return $this->getMessage(2000, $email, [], Craft::t('mailchimp-subscribe', 'API Key or Audience ID not supplied. Check your settings.'));
         }
 
@@ -697,7 +697,7 @@ class MailchimpSubscribeService extends Component
     private function getClient(): Mailchimp
     {
         $settings = Plugin::$plugin->getSettings();
-        return new Mailchimp(Craft::parseEnv($settings->apiKey));
+        return new Mailchimp(Craft::parseEnv($settings->getApiKey()));
     }
 
     /**
@@ -715,12 +715,12 @@ class MailchimpSubscribeService extends Component
         if ($settings->listId !== '') {
             Craft::$app->deprecator->log(__METHOD__ . '_listId_setting', 'The Mailchimp Subscribe config setting `listId` has been deprecated and will be removed in the next major version. Use `audienceId` instead.');
 
-            if ($settings->audienceId === '') {
+            if ($settings->getAudienceId() === '') {
                 $settings->audienceId = $settings->listId;
             }
         }
 
-        $audienceId = !empty($audienceId) ? $audienceId : $settings->audienceId;
+        $audienceId = !empty($audienceId) ? $audienceId : $settings->getAudienceId();
 
         // split id string on | in case more than one list id is supplied
         $audienceIdArr = explode('|', $audienceId);


### PR DESCRIPTION
Hey there
I'm using the plugin for a large multisite install where a couple if sites use Mailchimp for their newsletters and it would be really usefull to have multisite support in the plugin settings.

This PR adds that through Craft's `ConfigHelper::localizedValue`.

