### PR TITLE
Fix error when subscibing without adding tags

### DIFF
--- a/src/services/MailchimpSubscribeService.php
+++ b/src/services/MailchimpSubscribeService.php
@@ -150,7 +150,7 @@ class MailchimpSubscribeService extends Component
         }
 
         // Add tags to member if they were submitted.
-        if ($opts['tags'] !== null) {
+        if (isset($opts['tags']) && $opts['tags'] !== null) {
             try {
                 $tags = $this->prepMemberTags($opts['tags'], $result['tags']);
                 $tagsResult = $mc->request('lists/' . $audienceId . '/members/' . md5(strtolower($email)) . '/tags', ['tags' => $tags], 'POST');


### PR DESCRIPTION
Fixes “Undefined index: tags” error. Expands 3c29360765cb9f543290df32a1e788f20b57a169 commit.