### PR TITLE
Added support for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,74 @@ Again, make sure your form actually is GDPR compliant, and don't blame me.
 
 ---
 
+## Events
+
+There are several events that enable the ability for you to trigger custom code.
+Right now we have events for the subscribe, unsubscribe and delete actions that occur.
+All events should be listened to using the MailchimpSubscribeService class, examples can be found below
+
+### onAfterSubscribe
+
+The onAfterSubscribe event is triggered whenever a successful subscribe action has occurred. The SubscribeEvent class will
+contain the following properties:
+- (string) email
+- (string) audienceId
+
+```php
+use aelvan\mailchimpsubscribe\events\SubscribeEvent;
+use aelvan\mailchimpsubscribe\services\MailchimpSubscribeService;
+
+Event::on(
+    MailchimpSubscribeService::class,
+    MailchimpSubscribeService::EVENT_AFTER_SUBSCRIBE,
+    function (SubscribeEvent $event) {
+        // custom logic
+    }
+);
+```
+
+### onAfterUnsubscribe
+
+The onAfterSubscribe event is triggered whenever a successful unsubscribe action has occurred. The UnsubscribeEvent class will
+contain the following properties:
+- (string) email
+- (string) audienceId
+
+```php
+use aelvan\mailchimpsubscribe\events\UnsubscribeEvent;
+use aelvan\mailchimpsubscribe\services\MailchimpSubscribeService;
+
+Event::on(
+    MailchimpSubscribeService::class,
+    MailchimpSubscribeService::EVENT_AFTER_UNSUBSCRIBE,
+    function (UnsubscribeEvent $event) {
+        // custom logic
+    }
+);
+```
+### onAfterDelete
+
+The onAfterDelete event is triggered whenever a successful delete action has occurred. The DeleteEvent class will
+contain the following properties:
+- (string) email
+- (string) audienceId
+- (bool) permanent
+
+```php
+use aelvan\mailchimpsubscribe\events\DeleteEvent;
+use aelvan\mailchimpsubscribe\services\MailchimpSubscribeService;
+
+Event::on(
+    MailchimpSubscribeService::class,
+    MailchimpSubscribeService::EVENT_AFTER_DELETE,
+    function (DeleteEvent $event) {
+        // custom logic
+    }
+);
+```
+
+---
+
 ## Controller actions
 
 All controller actions: 

--- a/src/events/DeleteEvent.php
+++ b/src/events/DeleteEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace aelvan\mailchimpsubscribe\events;
+
+use yii\base\Event;
+
+class DeleteEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var string
+     */
+    public $email;
+
+    /**
+     * @var string
+     */
+    public $audienceId;
+
+    /**
+     * @var bool
+     */
+    public $permanent;
+}

--- a/src/events/SubscribeEvent.php
+++ b/src/events/SubscribeEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace aelvan\mailchimpsubscribe\events;
+
+use yii\base\Event;
+
+class SubscribeEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var string
+     */
+    public $email;
+
+    /**
+     * @var string
+     */
+    public $audienceId;
+}

--- a/src/events/UnsubscribeEvent.php
+++ b/src/events/UnsubscribeEvent.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace aelvan\mailchimpsubscribe\events;
+
+use yii\base\Event;
+
+class UnsubscribeEvent extends Event
+{
+    // Properties
+    // =========================================================================
+
+    /**
+     * @var string
+     */
+    public $email;
+
+    /**
+     * @var string
+     */
+    public $audienceId;
+}


### PR DESCRIPTION
This PR adds basic event logic to the plugin and documentation for its usage in the README.md such as the available fields, how to listen for the events and which classes are being used. I've already used my fork in a project of ours, and everything reacts exactly as expected.