### PR TITLE
Interest-categories max .count 100

### DIFF
--- a/src/services/MailchimpSubscribeService.php
+++ b/src/services/MailchimpSubscribeService.php
@@ -521,7 +521,7 @@ class MailchimpSubscribeService extends Component
                 $categoryData['interests'] = [];
 
                 /** @var Collection $interestsResult */
-                $interestsResult = $mc->request('lists/' . $audienceId . '/interest-categories/' . $category->id . '/interests');
+                $interestsResult = $mc->request('lists/' . $audienceId . '/interest-categories/' . $category->id . '/interests&count=100');
 
                 foreach ($interestsResult['interests'] as $interest) {
                     $interestData = [];


### PR DESCRIPTION
By default Mailchimp returns max. 10 interest-categories.